### PR TITLE
Allow setting registry API limit from node def

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,6 +85,9 @@ default['openstack']['image']['api']['workers'] = [8, node['cpu']['total'].to_i]
 # Set the number of registry workers
 default['openstack']['image']['registry']['workers'] = [8, node['cpu']['total'].to_i].min
 
+# Set the maximum number of API results
+default['openstack']['image']['registry']['api_limit_max'] = 1000
+
 # Return the URL that references where the data is stored on the backend.
 default['openstack']['image']['api']['show_image_direct_url'] = 'False'
 

--- a/templates/default/glance-registry.conf.erb
+++ b/templates/default/glance-registry.conf.erb
@@ -48,7 +48,7 @@ workers = <%= node["openstack"]["image"]["registry"]["workers"] %>
 
 # Limit the api to return `param_limit_max` items in a call to a container. If
 # a larger `limit` query param is provided, it will be reduced to this value.
-api_limit_max = 1000
+api_limit_max = <%= node["openstack"]["image"]["registry"]["api_limit_max"] %>
 
 # If a `limit` query param is not provided in an api request, it will
 # default to `limit_param_default`


### PR DESCRIPTION
As it turns out, my organization has a _ton_ of images in our registry (a hair over 1,000, in fact!) and being able to receive the whole list of images, particularly in communications between Horizon and Glance, would be super nice. The commit in this pull request simply allows specification of an api_limit_max in a node definition and declares a default of 1,000 (as is in the glance-registry.conf template already).
